### PR TITLE
Fix for UNIX-like mouse snapping

### DIFF
--- a/src/WasdEditorCameraBehaviour.cs
+++ b/src/WasdEditorCameraBehaviour.cs
@@ -316,7 +316,13 @@ namespace WasdEditorCamera
 
 			cursorLocker.LockUpdate ();
 
-			bool isDown = Input.GetKey (KeyCode.Mouse1);
+			int p = (int) Environment.OSVersion.Platform;
+			if ((p == 4) || (p == 6) || (p ==128)) {
+				bool isDown = Input.GetKey (KeyCode.Mouse2);
+			} else {
+				bool isDown = Input.GetKey (KeyCode.Mouse1);
+			}
+
 			bool goneDown = isDown && !mouseWasDown;
 			bool goneUp = !isDown && mouseWasDown;
 			mouseWasDown = isDown;


### PR DESCRIPTION
Rebound the look around to middle click on UNIX-like systems so that people can tweak in peace, without the part needing to be in the center